### PR TITLE
changes to error checking for header, empty or bad payload and more logs

### DIFF
--- a/source/CDC.DEX.FHIR.Function/CDC.DEX.FHIR.Function.ProcessMessage/CDC.DEX.FHIR.Function.ProcessMessage.sln
+++ b/source/CDC.DEX.FHIR.Function/CDC.DEX.FHIR.Function.ProcessMessage/CDC.DEX.FHIR.Function.ProcessMessage.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.002.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CDC.DEX.FHIR.Function.ProcessMessage", "CDC.DEX.FHIR.Function.ProcessMessage.csproj", "{8E47FD1B-0F67-4A27-AB45-5D688CAA445F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8E47FD1B-0F67-4A27-AB45-5D688CAA445F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8E47FD1B-0F67-4A27-AB45-5D688CAA445F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8E47FD1B-0F67-4A27-AB45-5D688CAA445F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8E47FD1B-0F67-4A27-AB45-5D688CAA445F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4B6FEEDB-94DD-4884-8EEA-4FC2726A6859}
+	EndGlobalSection
+EndGlobal

--- a/source/CDC.DEX.FHIR.Function/CDC.DEX.FHIR.Function.ProcessMessage/ProcessMessage.cs
+++ b/source/CDC.DEX.FHIR.Function/CDC.DEX.FHIR.Function.ProcessMessage/ProcessMessage.cs
@@ -39,9 +39,11 @@ namespace CDC.DEX.FHIR.Function.ProcessMessage
             [HttpTrigger(AuthorizationLevel.Function, "post", Route = null)] HttpRequest req,
             ILogger log)
         {
-
-            ContentResult contentResult = new ContentResult();
-            contentResult.ContentType = "application/fhir+json";
+            DateTime startProcessMessage = DateTime.Now;
+            ContentResult contentResult = new ContentResult
+            {
+                ContentType = "application/fhir+json"
+            };
 
             try
             {
@@ -96,9 +98,10 @@ namespace CDC.DEX.FHIR.Function.ProcessMessage
 
                 string cleanedBearerToken = CleanBearerToken(req.Headers[authorizationKeyName]);
 
+                DateTime startFHIRValidation = DateTime.Now;
                 PostContentBundleResult validateReportingBundleResult = await PostContentBundle(configuration, jsonString, location, cleanedBearerToken, log);
-
-                log.LogInformation("ProcessMessage validation done with result: " + TruncateStrForLog(validateReportingBundleResult.JsonString, maxLengthForLog));
+                TimeSpan durationFHIRValidation = DateTime.Now - startFHIRValidation;
+                log.LogInformation($"ProcessMessage validation done, duration ms: {durationFHIRValidation.Milliseconds} result: " + TruncateStrForLog(validateReportingBundleResult.JsonString, maxLengthForLog));
                 // log.LogInformation("ProcessMessage validation done with result: " + validateReportingBundleResult.JsonString);
 
 
@@ -155,6 +158,12 @@ namespace CDC.DEX.FHIR.Function.ProcessMessage
                 return contentResult;
 
             } // .catch
+            finally 
+            {
+                TimeSpan durationProcessMessage = DateTime.Now - startProcessMessage;
+                log.LogInformation($"ProcessMessage run duration ms: {durationProcessMessage.Milliseconds}");
+
+            }
 
         } // .run
 

--- a/source/CDC.DEX.FHIR.Function/CDC.DEX.FHIR.Function.ProcessMessage/ProcessMessage.cs
+++ b/source/CDC.DEX.FHIR.Function/CDC.DEX.FHIR.Function.ProcessMessage/ProcessMessage.cs
@@ -47,7 +47,7 @@ namespace CDC.DEX.FHIR.Function.ProcessMessage
 
             try
             {
-                log.LogInformation("C# HTTP trigger function processed a request.");
+                log.LogInformation("ProcessMessage HTTP trigger function received a request.");
 
                 // limit log of bundles or validation result to the first 100 chars
                 const int maxLengthForLog = 500;
@@ -101,8 +101,8 @@ namespace CDC.DEX.FHIR.Function.ProcessMessage
                 DateTime startFHIRValidation = DateTime.Now;
                 PostContentBundleResult validateReportingBundleResult = await PostContentBundle(configuration, jsonString, location, cleanedBearerToken, log);
                 TimeSpan durationFHIRValidation = DateTime.Now - startFHIRValidation;
-                log.LogInformation($"ProcessMessage validation done with result: " + TruncateStrForLog(validateReportingBundleResult.JsonString, maxLengthForLog));
-                log.LogInformation($"ProcessMessage validation run duration ms: {durationFHIRValidation.Milliseconds}");
+                log.LogInformation($"ProcessMessage FHIR validation done with result: " + TruncateStrForLog(validateReportingBundleResult.JsonString, maxLengthForLog));
+                log.LogInformation($"ProcessMessage FHIR validation run duration ms: {durationFHIRValidation.Milliseconds}");
                 
                 // log.LogInformation("ProcessMessage validation done with result: " + validateReportingBundleResult.JsonString);
 
@@ -110,7 +110,7 @@ namespace CDC.DEX.FHIR.Function.ProcessMessage
                 bool isValid;
                 if (flagProcessMessageFunctionSkipValidate)
                 {
-                    log.LogInformation("Skipping ProcessMessage Validation");
+                    log.LogInformation("ProcessMessage Skipping FHIR Validation");
                     isValid = true;
                 }
                 else
@@ -163,7 +163,7 @@ namespace CDC.DEX.FHIR.Function.ProcessMessage
             finally 
             {
                 TimeSpan durationProcessMessage = DateTime.Now - startProcessMessage;
-                log.LogInformation($"ProcessMessage run duration ms: {durationProcessMessage.Milliseconds}");
+                log.LogInformation($"ProcessMessage total run duration ms: {durationProcessMessage.Milliseconds}");
 
             }
 
@@ -173,7 +173,7 @@ namespace CDC.DEX.FHIR.Function.ProcessMessage
         {
             PostContentBundleResult postContentResponse;
 
-            log.LogInformation($"PostContentBundle, sending for validation to FHIR server endpoint: {location.AbsoluteUri}");
+            log.LogInformation($"ProcessMessage, PostContentBundle sending for validation to FHIR server endpoint: {location.AbsoluteUri}");
 
             using (HttpClient client = httpClientFactory.CreateClient())
             using (var request = new HttpRequestMessage(HttpMethod.Post, location) { Content = new StringContent(bundleJson, System.Text.Encoding.UTF8, "application/json") })
@@ -191,7 +191,7 @@ namespace CDC.DEX.FHIR.Function.ProcessMessage
 
                 string jsonString = await response.Content.ReadAsStringAsync();
 
-                log.LogInformation($"PostContentBundle, received from FHIR server http response status code success: {response.IsSuccessStatusCode}");
+                log.LogInformation($"ProcessMessage, PostContentBundle received from FHIR server http response status code success: {response.IsSuccessStatusCode}");
 
                 postContentResponse = new PostContentBundleResult() { StatusCode = response.StatusCode, JsonString = jsonString };
             }

--- a/source/CDC.DEX.FHIR.Function/CDC.DEX.FHIR.Function.ProcessMessage/ProcessMessage.cs
+++ b/source/CDC.DEX.FHIR.Function/CDC.DEX.FHIR.Function.ProcessMessage/ProcessMessage.cs
@@ -140,12 +140,12 @@ namespace CDC.DEX.FHIR.Function.ProcessMessage
             // catch (HttpRequestException e)
             catch( Exception e)
             {
-                if (e is HttpRequestException httpException)
+                if (e is HttpRequestException httpException) // exception returned from the FHIR server call
                 {
                     contentResult.Content = JsonErrorStr($"http error {httpException.StatusCode}");
                     contentResult.StatusCode = (int)httpException.StatusCode;
                 }
-                    else 
+                    else // something else (exception) happened
                 {
                     contentResult.Content = JsonErrorStr("unexpected condition was encountered");
                     contentResult.StatusCode = 500; // code for internal server error as exception

--- a/source/CDC.DEX.FHIR.Function/CDC.DEX.FHIR.Function.ProcessMessage/ProcessMessage.cs
+++ b/source/CDC.DEX.FHIR.Function/CDC.DEX.FHIR.Function.ProcessMessage/ProcessMessage.cs
@@ -101,7 +101,9 @@ namespace CDC.DEX.FHIR.Function.ProcessMessage
                 DateTime startFHIRValidation = DateTime.Now;
                 PostContentBundleResult validateReportingBundleResult = await PostContentBundle(configuration, jsonString, location, cleanedBearerToken, log);
                 TimeSpan durationFHIRValidation = DateTime.Now - startFHIRValidation;
-                log.LogInformation($"ProcessMessage validation done, duration ms: {durationFHIRValidation.Milliseconds} result: " + TruncateStrForLog(validateReportingBundleResult.JsonString, maxLengthForLog));
+                log.LogInformation($"ProcessMessage validation done with result: " + TruncateStrForLog(validateReportingBundleResult.JsonString, maxLengthForLog));
+                log.LogInformation($"ProcessMessage validation run duration ms: {durationFHIRValidation.Milliseconds}");
+                
                 // log.LogInformation("ProcessMessage validation done with result: " + validateReportingBundleResult.JsonString);
 
 


### PR DESCRIPTION
- error checking for header, empty or bad payload as to return to sender info and not exception crash function

-  and more and improved logs, truncated long bundle or validation logs